### PR TITLE
doc: fix typo "token" => "api_token"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use this module for the ACME DNS challenge, [configure the ACME issuer in you
           "dns": {
               "provider": {
                  "name":   "namedotcom",
-                 "token":  "{env.NAMEDOTCOM_TOKEN}",
+                 "api_token":  "{env.NAMEDOTCOM_TOKEN}",
                  "user":   "{env.NAMEDOTCOM_USER}",
                  "server": "{env.NAMEDOTCOM_SERVER}"
               }


### PR DESCRIPTION
Re: #1 

Caddyfile uses `token` but JSON config uses `api_token`.